### PR TITLE
DTSW-7754 Fix incorrect EVERY_2_HOURS frequency constant

### DIFF
--- a/packages/online/constants.py
+++ b/packages/online/constants.py
@@ -77,4 +77,4 @@ class FREQUENCY:
     EVERY_10_MINUTES = 1.0 / (60 * 10)
     EVERY_30_MINUTES = 1.0 / (60 * 30)
     EVERY_1_HOUR = 1.0 / (60 * 60 * 1)
-    EVERY_2_HOURS = 1.0 / (60 * 60 * 1)
+    EVERY_2_HOURS = 1.0 / (60 * 60 * 2)


### PR DESCRIPTION
## Jira
DTSW-7754

## Bug
EVERY_2_HOURS constant was incorrectly set to the same value as EVERY_1_HOUR.

## Impact
Providers intended to run every 2 hours were running every hour, increasing unnecessary data collection and system load.

## Fix
Updated EVERY_2_HOURS to correct value: 1/(60*60*2).

## Verification
Confirmed frequency now correctly represents a 2-hour interval.